### PR TITLE
Changeset for support Luminous 12.2.2

### DIFF
--- a/check-ceph-dash.py
+++ b/check-ceph-dash.py
@@ -33,7 +33,10 @@ class CephClusterStatus(dict):
             return ('UNKNOWN', 3)
 
     def get_perf_data(self):
-        nagios_str, nagios_exit = self._map(self['health']['overall_status'])
+        if 'status' in self['health']:
+            nagios_str, nagios_exit = self._map(self['health']['status'])
+        else:
+            nagios_str, nagios_exit = self._map(self['health']['overall_status'])
         if nagios_exit == 3:
             return ""
 
@@ -65,7 +68,10 @@ class CephClusterStatus(dict):
         return perfdata
 
     def get_exit_code(self):
-        nagios_str, nagios_exit = self._map(self['health']['overall_status'])
+        if 'status' in self['health']:
+            nagios_str, nagios_exit = self._map(self['health']['status'])
+        else:
+            nagios_str, nagios_exit = self._map(self['health']['overall_status'])
         return int(nagios_exit)
 
     def get_nagios_string(self):
@@ -76,10 +82,10 @@ class CephClusterStatus(dict):
         if nagios_exit == 0:
             summary = 'ceph cluster operates with no problems'
         else:
-            if 'summary' in self['health']:
-                summary = '\n'.join([ "{severity}: {summary}".format(**problems) for problems in self['health']['summary']])
-            elif 'checks' in self['health']:
+            if 'checks' in self['health']:
                 summary = '\n'.join([ "{severity}: {summary[message]}".format(**problems) for problems in self['health']['checks'].values()])
+            elif 'summary' in self['health']:
+                summary = '\n'.join([ "{severity}: {summary}".format(**problems) for problems in self['health']['summary']])
             else:
                 summary = 'Unable to fetch healt details. Please check cluster directly'
 


### PR DESCRIPTION
After upgrade from Kraken to Luminous 12.2.2:

```python
Traceback (most recent call last):
  File "./check_ceph_dash.py", line 99, in <module>
    main()
  File "./check_ceph_dash.py", line 95, in main
    print "%s|%s" % (status.get_nagios_string(), status.get_perf_data())
  File "./check_ceph_dash.py", line 36, in get_perf_data
    nagios_str, nagios_exit = self._map(self['health']['overall_status'])
KeyError: 'overall_status'
```